### PR TITLE
Set mamba as default for Mac install

### DIFF
--- a/docs/guide/host_pc/setup_mac.md
+++ b/docs/guide/host_pc/setup_mac.md
@@ -42,14 +42,8 @@ conda env remove -n donkey
 
 * Create the Python anaconda environment
 
-```bash
-conda env create -f install/envs/mac.yml
-conda activate donkey
-pip install -e .[pc]
-```
-We have observed that the `conda` installation can be slow (not as slow in OSX as in Linux, but 
-still slow). If the install looks like it's hanging then you can install with `mamba` instead. 
-This should take < 5 min. In that case please run:
+Recommended (faster install time):
+
 ```bash
 conda install mamba -n base -c conda-forge
 mamba env create -f install/envs/mac.yml
@@ -57,6 +51,16 @@ conda activate donkey
 pip install -e .[pc]
 ```
 Note: if you are using ZSH (you'll know if you are), you won't be able to run `pip install -e .[pc]`. You'll need to escape the brackets and run `pip install -e .\[pc\]`.
+
+Alternative (slower install time):
+
+```bash
+conda env create -f install/envs/mac.yml
+conda activate donkey
+pip install -e .[pc]
+```
+We have observed that the `conda` installation can be slow (not as slow in OSX as in Linux, but 
+still slow). If the install looks like it's hanging then you can install with `mamba` instead (above). 
 
 * Tensorflow GPU
 


### PR DESCRIPTION
Without mamba conda env create -f install/envs/mac.yml requires > 30 minutes.  Mamba takes < 5 minutes.